### PR TITLE
Ensure that compilers return dependent files for files with dependencies

### DIFF
--- a/test/compiler-valid-invalid.js
+++ b/test/compiler-valid-invalid.js
@@ -118,7 +118,7 @@ for (let mimeType of mimeTypesToTest) {
         let ctx = {};
         let source = await pfs.readFile(input, 'utf8');
         let dependentFiles = await this.fixture.determineDependentFiles(source, input, ctx);
-        expect(dependentFiles.length).to.equal(2);
+        expect(dependentFiles).to.have.length.above(0);
       });
     }
   });

--- a/test/compiler-valid-invalid.js
+++ b/test/compiler-valid-invalid.js
@@ -33,6 +33,10 @@ const mimeTypesWithoutSourceMapSupport = [
   'text/css'
 ];
 
+const mimeTypesWithDependentFilesSupport = [
+  'text/less'
+];
+
 const compilerOptionsForMimeType = {
   'application/javascript': {
     "presets": ["es2016-node5"],
@@ -105,5 +109,17 @@ for (let mimeType of mimeTypesToTest) {
       let result = this.fixture.compile(source, input, ctx);
       expect(result).to.eventually.throw();
     });
+
+    if (mimeTypesWithDependentFilesSupport.includes(mimeType)) {
+      it(`should return a non-empty array of dependent files if a file has dependencies`, async function() {
+        let ext = mimeTypes.extension(mimeType);
+        let input = path.join(__dirname, '..', 'test', 'fixtures', `file-with-dependencies.${ext}`);
+
+        let ctx = {};
+        let source = await pfs.readFile(input, 'utf8');
+        let dependentFiles = await this.fixture.determineDependentFiles(source, input, ctx);
+        expect(dependentFiles.length).to.equal(2);
+      });
+    }
   });
 }

--- a/test/fixtures/dependency-a.less
+++ b/test/fixtures/dependency-a.less
@@ -1,0 +1,1 @@
+@about-dialog-color: #a62ee4;

--- a/test/fixtures/dependency-b.less
+++ b/test/fixtures/dependency-b.less
@@ -1,0 +1,1 @@
+@about-dialog-size: #f4e2d1;

--- a/test/fixtures/file-with-dependencies.less
+++ b/test/fixtures/file-with-dependencies.less
@@ -1,0 +1,10 @@
+@import "./dependency-a";
+@import "./dependency-b";
+
+.About {
+  .dialog {
+    font-weight: bold;
+    color: @about-dialog-color;
+    font-size: @about-dialog-size;
+  }
+}


### PR DESCRIPTION
Depends on https://github.com/electron/electron-compilers/pull/38

This adds a test to make sure that classes that implement `determineDependentFiles` actually return non-empty arrays for files with dependencies.
