### PR TITLE
Add method to bypass the compilers completely

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,9 @@ import FileChangedCache from './file-change-cache';
 import CompileCache from './compile-cache';
 import {enableLiveReload} from './live-reload';
 import {watchPath} from './pathwatcher-rx';
+import {addBypassChecker} from './protocol-hook';
 
 module.exports = Object.assign({},
   configParser,
-  { enableLiveReload, watchPath, CompilerHost, FileChangedCache, CompileCache }
+  { enableLiveReload, watchPath, CompilerHost, FileChangedCache, CompileCache, addBypassChecker }
 );


### PR DESCRIPTION
Fixes https://github.com/electron-userland/electron-forge/issues/153

The reason I added this instead of a new `bypass://` protocol or similar is because (on windows at least) the file path passed to the Electron protocol handler only works as expected on `file://` not on any other URI's, it just get's completely messed up.  This would seem to achieve what the above issue needs to so I think it's good enough for now :+1:.

Users can now just do this.
```js
import { addBypassChecker } from 'electron-compile';

addBypassChecker((filePath) => {
  return /\.mp4/.test(filePath);
});
```

Or something similar, the more common use case might be a function like this (untested).

```js
import { app } from 'electron';
import { addBypassChecker } from 'electron-compile';

addBypassChecker((filePath) => {
  return filePath.indexOf(app.getAppPath()) === -1;
});
```

Which would theoretically bypass `electron-compile` for all files **not** in the current app.